### PR TITLE
Remove title header from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-# [Beeminder Wiki](https://wiki.beeminder.com/)
-
 <script async src="https://cse.google.com/cse.js?cx=47d883c203399aec4"></script>
 <div class="gcse-search"></div>
 


### PR DESCRIPTION
As @dreeves pointed out in the Discord server, the website version automatically generated by GitHub Pages automatically adds a title to the page, causing the one in the readme to be redundant. (This could be changed if a theme was used, but that just opens up a whole other can of worms).