### PR TITLE
Wiki copyedit: fix typos and a broken internal link

### DIFF
--- a/wiki/integrations.md
+++ b/wiki/integrations.md
@@ -132,7 +132,7 @@ P. S.: Searching for the topics [beeminder][55] or
 
 ### Libraries
 
-- Angular/Ionic - [beeminder-capstone/Nectar-Frontend][71] - by @nectar
+- Angular/Ionic - [beeminder-capstone/Nectar-Frontend][77] - by @nectar
 - Emacs - [mbork/beeminder.el][71] - @mbork
 - Mathematica [beeminder/wolfminder][72] -by @dreev
 - NodeJS [malcolmocean/beeminderjs][60] - by @malcolm
@@ -153,8 +153,8 @@ P. S.: Searching for the topics [beeminder][55] or
 ### Web
 
 - [Beeminder Autodialer][87] - by @narthur. "The Beeminder autodialer will automatically adjust the rate on your goals based on your historical performance."
-- [Beeminder Panel][88] - by @narthur. An experimental web dashboard alernative to the Beeminder web app.
-- [Beescheduler][89] - by [@enolan][90]. "Beescheduler lets you schedule different rates for your Beeminder goals based on the days of the week. I wrote it so I could focus on one project Monday - Wednesday and different ones on Thursday and Friday. This is much better than doing a tiny amount on all of them every day." [Forum announcmenet.][91]
+- [Beeminder Panel][88] - by @narthur. An experimental web dashboard alternative to the Beeminder web app.
+- [Beescheduler][89] - by [@enolan][90]. "Beescheduler lets you schedule different rates for your Beeminder goals based on the days of the week. I wrote it so I could focus on one project Monday - Wednesday and different ones on Thursday and Friday. This is much better than doing a tiny amount on all of them every day." [Forum announcement.][91]
 - [chipmanaged/MCM-Dashboard][92] - by @mary, includes an autodial feature and
   umbrella goals feature, see [this thread][93]
 - [Altbee][94] - "an alternative web interface for Beeminder."

--- a/wiki/tutorials.md
+++ b/wiki/tutorials.md
@@ -28,10 +28,10 @@ Below are instructions for creating a simple custom RSS integration with Make.co
 *   If you haven't already connected Beeminder to your Make.com account, click the "Add" button next to the "Connection" field.
 *   A new dialog will appear requesting your Beeminder auth token. Copy your auth token [from this url][5] into the auth token field in Make.com.
 *   Click "Continue."
-*   If the connection was successful, addition fields should appear underneath the "Connection" field.
+*   If the connection was successful, additional fields should appear underneath the "Connection" field.
 *   Select your desired goal in the "Goal" field.
 *   In the "Value" field, enter the number 1. This will set the value of each new datapoint to 1 in Beeminder.
-*   Leave "Timestamp" and "Daystamp" epty to default to the time the datapoint is created.
+*   Leave "Timestamp" and "Daystamp" empty to default to the time the datapoint is created.
 *   Decide what you'd like to include in the "Comment" field. You can access data from previous modules in the flow by clicking in the field. For example, you could add the RSS item's Title and URL by clicking those items in the list that appears when you place your cursor in the field.
 *   Leave the "Request ID" blank.
 *   Click "OK."


### PR DESCRIPTION
A small content-quality pass over the wiki, found while reviewing the pages.

## Fixes

**Typos**
- `wiki/tutorials.md` — "addition fields" → "additional fields"; "epty" → "empty"
- `wiki/integrations.md` — "alernative" → "alternative"; "announcmenet" → "announcement"

**Broken internal link**
- `wiki/integrations.md` — In the Libraries section, the Angular/Ionic **Nectar-Frontend** entry used reference `[71]`, which is defined as `mbork/beeminder.el` (the Emacs library). So that link silently pointed at the wrong repo. Repointed it to `[77]` (`beeminder-capstone/Nectar-Frontend`), the same repo the Mobile Apps "Nectar" entry already uses.

## Verified
`vitepress build` succeeds.

## Noted but intentionally left alone
- `integrations.md` Meta section has two entries rendered with escaped brackets — `\[through Beemind.me]\[47]` — so they show as literal text rather than links, and reference `[47]` is make.com, not beemind.me. Fixing this correctly needs the intended Beemind.me URL, so I left it for a maintainer who knows the intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)