### PR TITLE
Wiki copyedit round 2: grammar and product-name casing

### DIFF
--- a/wiki/getting-started.md
+++ b/wiki/getting-started.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-If you'd like to view the official documentation and guides on getting started with Beeminder, here's some helpful links from the official website:
+If you'd like to view the official documentation and guides on getting started with Beeminder, here are some helpful links from the official website:
 
 *   [**A Newbie Guide**][1] to getting started with Beeminder. (Called *newbee*, get it?)
 *   [**An Overview**][2] of what Beeminder is.

--- a/wiki/integrations.md
+++ b/wiki/integrations.md
@@ -245,7 +245,7 @@ NOTE: Nectar is currently not active, see [this post][115] for details. The proj
   [Integration docs][134].
 - Taskwarrior - by @openmedi :nerd_face: see
   [this thread][135] \[broken GitHub link]
-- ToDoIst - Todos - [official][46]
+- Todoist - Todos - [official][46]
 - Trello - Cards moved to or from a list or board - [official][46]
 
 ## Reading, Bookmarking

--- a/wiki/what-is-beeminder.md
+++ b/wiki/what-is-beeminder.md
@@ -1,6 +1,6 @@
 # What Is Beeminder?
 
-Beeminder is a service that helps you keep track of what you *want* to be doing, but maybe are having trouble actually following-through. It takes data, either that you enter or that's automatically entered from dozens of different services (see [Integrations][1]), and it keeps track of data in a cool graph! The catch is that you set an amount you must do per day/week/month, and if that amount isn't met then you get charged money. That's the *sting* of Beeminder!
+Beeminder is a service that helps you keep track of what you *want* to be doing, but maybe are having trouble actually following through. It takes data, either that you enter or that's automatically entered from dozens of different services (see [Integrations][1]), and it keeps track of data in a cool graph! The catch is that you set an amount you must do per day/week/month, and if that amount isn't met then you get charged money. That's the *sting* of Beeminder!
 
 <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/ILf8yPNSbZY" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 


### PR DESCRIPTION
A second small content-quality pass, following #13.

## Fixes
- **`what-is-beeminder.md`** — "following-through" → "following through" (it's a verb phrase here, so no hyphen)
- **`getting-started.md`** — "here's some helpful links" → "here are some helpful links" (subject–verb agreement with the plural "links")
- **`integrations.md`** — "ToDoIst" → "Todoist", matching the product's official casing used in every other mention across the wiki

## Verified
`vitepress build` succeeds. No undefined/broken reference links remain after a full audit of all pages.

## Investigated, intentionally left alone
- The `integrations.md` Meta entries that render as literal `[through Beemind.me][47]` are **deliberate**: commit `9a3b784 "remove beemind.me"` escaped the brackets on purpose to disable the dead beemind.me link while keeping the text. Left as-is. (If you'd rather drop those two now-linkless entries entirely, say the word and I'll do it.)
- The unused `[4]`–`[44]` in `integrations.md` are stale in-page anchor reference definitions tied to the auto-generated Table of Contents; removing them would trigger large renumber churn from the `renumber-references`/`toc` plugins, so I left them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)